### PR TITLE
fix: add NET_ADMIN/TUN device for marzban and fix macOS button label

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,10 @@ services:
   marzban:
     image: gozargah/marzban:v0.8.4
     container_name: vpn_marzban
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun:/dev/net/tun
     restart: always
     dns:
       - 1.1.1.1

--- a/tgbot/keyboards/inline.py
+++ b/tgbot/keyboards/inline.py
@@ -133,7 +133,7 @@ def os_client_keyboard():
     builder.button(text="🤖 Android (Happ)", url="https://play.google.com/store/apps/details?id=com.happproxy")
     builder.button(text="🍏 iOS (Happ)", url="https://apps.apple.com/us/app/happ-proxy-utility/id6504287215")
     builder.button(text="💻 Windows (Happ)", url="https://github.com/Happ-proxy/happ-desktop/releases")
-    builder.button(text="🍎 macOS (Happ)", url="https://apps.apple.com/us/app/happ-proxy-utility/id6504287215?platform=mac")
+    builder.button(text="🍎 mac OS (Happ)", url="https://apps.apple.com/us/app/happ-proxy-utility/id6504287215?platform=mac")
     builder.button(text="⬅️ Назад в главное меню", callback_data="back_to_main_menu")
     builder.adjust(1) # Располагаем кнопки по одной в ряд
     return builder.as_markup()


### PR DESCRIPTION
- Add cap_add: NET_ADMIN and /dev/net/tun device to marzban service
- Fix macOS button text: "macOS" → "mac OS" in os_client_keyboard